### PR TITLE
重构：BillItem 引入 lifecycle 状态机，分离业务分类与处理状态

### DIFF
--- a/bill_classifier/bill_item.py
+++ b/bill_classifier/bill_item.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from enum import Enum
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from util import timestamp2str
 
 class BillType(Enum):
@@ -36,8 +36,14 @@ class BillItem:
         self.bill_time = bill_time      # 订单发生时间
         self.bill_source = bill_source  # 订单来源（alipay/wechat）
         self.owner = owner              # 账单人（zrz/cwx）
-        self.category = ExpenseCategory.UNKNOWN  # 分类
-        self.classify_alg = ClassifyAlg.UNKNOWN  # 识别模式
+        self.category = ExpenseCategory.UNKNOWN  # 分类（旧字段，迁移期保留）
+        self.classify_alg = ClassifyAlg.UNKNOWN  # 识别模式（旧字段，迁移期保留）
+        # 生命周期 / 状态机（lifecycle_refactor 引入）：
+        # 各 step 应根据 lifecycle 而不是 category != UNKNOWN 来判断"是否处理过"。
+        # 迁移期与旧 category 状态值（UNKNOWN/SKIP）双写，待全部 step 改造完成后
+        # 再从 ExpenseCategory 中移除状态值。
+        self.lifecycle = Lifecycle.UNPROCESSED
+        self.skip_reason = None             # SkipReason，仅 lifecycle == SKIPPED 时填
         # 策略上下文字段（按需由各 step 写入，默认 None 对其它 step 透明）
         self.neighbor_group = None          # 策略 4：相邻账单组 ID，同组紧邻输出
         self.taobao_balance_extra = None    # 策略 2：购物金合并后追加的说明文本

--- a/bill_classifier/bill_item.py
+++ b/bill_classifier/bill_item.py
@@ -19,7 +19,6 @@ class ClassifyAlg(Enum):
     WET_MARKET = "菜场模式"
     GPT = "GPT模式"
     NEIGHBOR = "相邻推断"
-    UNKNOWN = "无法识别"
 
     def to_str(self) -> str:
         return self.value
@@ -36,18 +35,30 @@ class BillItem:
         self.bill_time = bill_time      # 订单发生时间
         self.bill_source = bill_source  # 订单来源（alipay/wechat）
         self.owner = owner              # 账单人（zrz/cwx）
-        self.category = ExpenseCategory.UNKNOWN  # 分类（旧字段，迁移期保留）
-        self.classify_alg = ClassifyAlg.UNKNOWN  # 识别模式（旧字段，迁移期保留）
-        # 生命周期 / 状态机（lifecycle_refactor 引入）：
-        # 各 step 应根据 lifecycle 而不是 category != UNKNOWN 来判断"是否处理过"。
-        # 迁移期与旧 category 状态值（UNKNOWN/SKIP）双写，待全部 step 改造完成后
-        # 再从 ExpenseCategory 中移除状态值。
+        # 业务分类（None 表示未分类；展示用 category_display() 派生字符串）
+        self.category = None
+        # 哪个分类 step 完成（None 表示未分类）
+        self.classify_alg = None
+        # 生命周期：各 step 根据 lifecycle 判断"是否处理过"
         self.lifecycle = Lifecycle.UNPROCESSED
         self.skip_reason = None             # SkipReason，仅 lifecycle == SKIPPED 时填
         # 策略上下文字段（按需由各 step 写入，默认 None 对其它 step 透明）
         self.neighbor_group = None          # 策略 4：相邻账单组 ID，同组紧邻输出
         self.taobao_balance_extra = None    # 策略 2：购物金合并后追加的说明文本
         self.cross_month_origin = None      # 策略 3：跨月退款关联到的原支出条目 dict
+
+    def category_display(self) -> str:
+        """飞书表格'分类'列展示值（按 lifecycle 派生）。"""
+        if self.lifecycle == Lifecycle.CLASSIFIED and self.category is not None:
+            return self.category.to_str()
+        if self.lifecycle == Lifecycle.SKIPPED:
+            return "skip"
+        if self.lifecycle == Lifecycle.CROSS_MONTH_REFUND:
+            return "退款"
+        return "unknown"  # UNPROCESSED
+
+    def classify_alg_display(self) -> str:
+        return self.classify_alg.to_str() if self.classify_alg else "无法识别"
 
     def __str__(self):
         return """
@@ -62,5 +73,5 @@ Amount: {}
     category: {}""".format(
             self.amount, self.payee, self.item_name, self.bill_type.name,
             self.order_id, timestamp2str(self.bill_time), self.bill_source, self.owner,
-            self.category.to_str()
+            self.category_display()
         )

--- a/bill_classifier/category.py
+++ b/bill_classifier/category.py
@@ -33,6 +33,34 @@ class ExtraPayCategory(Enum):
     def to_str(self) -> str:
         return self.value
 
+
+class Lifecycle(Enum):
+    """BillItem 在 pipeline 中的处理状态。
+
+    替代旧设计中"用 ExpenseCategory.UNKNOWN/SKIP 表达状态"的隐式约定。
+    每个 step 处理完一条 item 后，应该把 lifecycle 推进到对应状态。
+    """
+    UNPROCESSED = "未处理"           # 默认初始状态
+    SKIPPED = "跳过"                # 不计入开销，具体原因看 skip_reason
+    CROSS_MONTH_REFUND = "跨月退款"  # 关联到上月原支出，左侧主表保留 + 右侧提醒
+    CLASSIFIED = "已分类"            # 已被分类为某 ExpenseCategory，看 category / classify_alg
+
+    def to_str(self) -> str:
+        return self.value
+
+
+class SkipReason(Enum):
+    """lifecycle == SKIPPED 时记录的原因，便于审计与未来调整。"""
+    FILTER = "filter"                # meican_filter：工作日餐补
+    BLACKLIST = "blacklist"          # skip_keywords：item_name 黑名单
+    NON_EXPENSE = "non_expense"      # bill_type ∈ {INCOME, OTHER} 不计入主表合计
+    ZERO_AMOUNT = "zero_amount"      # merge_refund / taobao_balance_merge 净额为 0
+    REFUND_NO_ORIG = "refund_no_orig"  # merge_refund 无 order_id（已知 bug，保持原行为）
+
+    def to_str(self) -> str:
+        return self.value
+
+
 expense_category_mapping = {category.value: category for category in ExpenseCategory}
 
 class CategoryInfo:

--- a/bill_classifier/category.py
+++ b/bill_classifier/category.py
@@ -4,24 +4,25 @@
 from enum import Enum
 
 class ExpenseCategory(Enum):
-    WATER_ELECTRICITY_PROPERTY = '水电物业'  # 水电物业
-    CATERING = '餐饮'  # 餐饮
-    BUY_VEGETABLES = '买菜'  # 买菜
-    TRANSPORTATION = '交通'  # 交通
-    DAILY_EXPENSES = '日常开支'  # 日常开支
-    CLOTHING_SHOES_HATS = '服装鞋帽'  # 服装鞋帽
-    SKINCARE_PRODUCTS = '护肤品'  # 护肤品
-    SOCIAL_INTERCOURSE = '人情往来'  # 人情往来
-    LEISURE_ENTERTAINMENT = '休闲娱乐'  # 休闲娱乐
-    COMPANY = '公司'  # 公司
-    HOME_CONSTRUCTION = '家庭建设'  # 家庭建设
-    MEDICAL = '医疗'  # 医疗
-    VEHICLE_MAINTENANCE = '养车'  # 养车
-    CHILD = "育儿"  # 育儿
-    UNKNOWN = 'unknown'
-    SKIP = 'skip'  # skip
-    REFUND = '退款'  # 退款
-    INCOME = "收入"  # 收入
+    """业务分类（仅业务含义，不含状态值）。
+
+    "未分类 / 跳过 / 退款 / 收入"等状态语义由 Lifecycle 表达；
+    展示层通过 BillItem.category_display() 派生表格字符串。
+    """
+    WATER_ELECTRICITY_PROPERTY = '水电物业'
+    CATERING = '餐饮'
+    BUY_VEGETABLES = '买菜'
+    TRANSPORTATION = '交通'
+    DAILY_EXPENSES = '日常开支'
+    CLOTHING_SHOES_HATS = '服装鞋帽'
+    SKINCARE_PRODUCTS = '护肤品'
+    SOCIAL_INTERCOURSE = '人情往来'
+    LEISURE_ENTERTAINMENT = '休闲娱乐'
+    COMPANY = '公司'
+    HOME_CONSTRUCTION = '家庭建设'
+    MEDICAL = '医疗'
+    VEHICLE_MAINTENANCE = '养车'
+    CHILD = "育儿"
 
     def to_str(self) -> str:
         return self.value
@@ -37,8 +38,8 @@ class ExtraPayCategory(Enum):
 class Lifecycle(Enum):
     """BillItem 在 pipeline 中的处理状态。
 
-    替代旧设计中"用 ExpenseCategory.UNKNOWN/SKIP 表达状态"的隐式约定。
     每个 step 处理完一条 item 后，应该把 lifecycle 推进到对应状态。
+    后续 step 通过 lifecycle != UNPROCESSED 判断"是否已处理"。
     """
     UNPROCESSED = "未处理"           # 默认初始状态
     SKIPPED = "跳过"                # 不计入开销，具体原因看 skip_reason

--- a/bill_classifier/classifiers/__init__.py
+++ b/bill_classifier/classifiers/__init__.py
@@ -4,6 +4,7 @@ from classifiers.merge_payee import MergePayee
 from classifiers.merge_refund import MergeRefund
 from classifiers.taobao_balance_merge import TaobaoBalanceMerge
 from classifiers.cross_month_unified import CrossMonthUnified
+from classifiers.non_expense_skip import NonExpenseSkip
 from classifiers.exact_match import ExactMatch
 from classifiers.regex_match import RegexMatch
 from classifiers.skip_keywords import SkipKeywords
@@ -17,6 +18,7 @@ DEFAULT_STEPS = [
     "merge_refund",
     "taobao_balance_merge",
     "cross_month_unified",
+    "non_expense_skip",
     "exact_match",
     "regex_match",
     "skip_keywords",
@@ -31,6 +33,7 @@ STEP_REGISTRY = {
     "merge_refund": MergeRefund,
     "taobao_balance_merge": TaobaoBalanceMerge,
     "cross_month_unified": CrossMonthUnified,
+    "non_expense_skip": NonExpenseSkip,
     "exact_match": ExactMatch,
     "regex_match": RegexMatch,
     "skip_keywords": SkipKeywords,

--- a/bill_classifier/classifiers/cross_month_unified.py
+++ b/bill_classifier/classifiers/cross_month_unified.py
@@ -32,6 +32,7 @@ import logging
 from typing import Callable, Dict, List, Optional, Tuple
 
 from bill_item import BillItem, BillType
+from category import Lifecycle
 from classifiers.base import Context, Step
 from classifiers.taobao_balance_merge import _extract_core_order_id
 
@@ -149,6 +150,7 @@ class CrossMonthUnified(Step):
             origin, status = self._lookup(orphan, core_oid_index, payee_amount_index)
             if origin is not None:
                 orphan.cross_month_origin = origin
+                orphan.lifecycle = Lifecycle.CROSS_MONTH_REFUND
                 match_count += 1
             elif status == "ambiguous":
                 ambiguous_count += 1

--- a/bill_classifier/classifiers/exact_match.py
+++ b/bill_classifier/classifiers/exact_match.py
@@ -25,7 +25,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, BillType, ClassifyAlg
-from category import ExpenseCategory, Lifecycle, SkipReason
+from category import Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -47,11 +47,12 @@ class ExactMatch(Step):
 
         mark_count = 0
         for item in items:
-            # 已被前置 step 处理过的（含 cross_month_unified 标的 CROSS_MONTH_REFUND）跳过
-            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
+            # 已被前置 step 处理过的（含 non_expense_skip 标的 SKIPPED 和
+            # cross_month_unified 标的 CROSS_MONTH_REFUND）跳过
+            if item.lifecycle != Lifecycle.UNPROCESSED:
                 continue
+            # 防御：理论上 non_expense_skip 已把非支出标 SKIPPED，不会到这里
             if item.bill_type != BillType.EXPENSE:
-                item.category = ExpenseCategory.SKIP  # 双写
                 item.lifecycle = Lifecycle.SKIPPED
                 item.skip_reason = SkipReason.NON_EXPENSE
                 continue

--- a/bill_classifier/classifiers/exact_match.py
+++ b/bill_classifier/classifiers/exact_match.py
@@ -25,7 +25,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, BillType, ClassifyAlg
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -47,21 +47,26 @@ class ExactMatch(Step):
 
         mark_count = 0
         for item in items:
-            if item.category != ExpenseCategory.UNKNOWN:
+            # 已被前置 step 处理过的（含 cross_month_unified 标的 CROSS_MONTH_REFUND）跳过
+            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
                 continue
             if item.bill_type != BillType.EXPENSE:
-                item.category = ExpenseCategory.SKIP
+                item.category = ExpenseCategory.SKIP  # 双写
+                item.lifecycle = Lifecycle.SKIPPED
+                item.skip_reason = SkipReason.NON_EXPENSE
                 continue
 
             if item.item_name in info.item_category_dict:
                 item.category = info.item_category_dict[item.item_name]
                 item.classify_alg = ClassifyAlg.MATCH
+                item.lifecycle = Lifecycle.CLASSIFIED
                 mark_count += 1
                 continue
 
             if item.payee in info.payee_category_dict:
                 item.category = info.payee_category_dict[item.payee]
                 item.classify_alg = ClassifyAlg.MATCH
+                item.lifecycle = Lifecycle.CLASSIFIED
                 mark_count += 1
 
         logger.debug("exact_match 标记 item size:{}".format(mark_count))

--- a/bill_classifier/classifiers/gpt.py
+++ b/bill_classifier/classifiers/gpt.py
@@ -25,7 +25,7 @@ import re
 from typing import List
 
 from bill_item import BillItem, ClassifyAlg
-from category import ExpenseCategory, Lifecycle, expense_category_mapping
+from category import Lifecycle, expense_category_mapping
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class GPTStep(Step):
         for item in items:
             if call_limit >= 0 and mark_count == call_limit:
                 break
-            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED:
                 continue
 
             if item.payee == '美团' or item.payee == '美团平台商户':

--- a/bill_classifier/classifiers/gpt.py
+++ b/bill_classifier/classifiers/gpt.py
@@ -25,7 +25,7 @@ import re
 from typing import List
 
 from bill_item import BillItem, ClassifyAlg
-from category import ExpenseCategory, expense_category_mapping
+from category import ExpenseCategory, Lifecycle, expense_category_mapping
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class GPTStep(Step):
         for item in items:
             if call_limit >= 0 and mark_count == call_limit:
                 break
-            if item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
                 continue
 
             if item.payee == '美团' or item.payee == '美团平台商户':
@@ -70,6 +70,7 @@ class GPTStep(Step):
 
             item.category = expense_category_mapping[text]
             item.classify_alg = ClassifyAlg.GPT
+            item.lifecycle = Lifecycle.CLASSIFIED
             mark_count += 1
 
         if hasattr(classifier, "get_token_count"):

--- a/bill_classifier/classifiers/meican_filter.py
+++ b/bill_classifier/classifiers/meican_filter.py
@@ -20,7 +20,7 @@ import re
 from typing import List
 
 from bill_item import BillItem
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,9 @@ class MeicanFilter(Step):
             is_work_hour = dt.hour == 18 or dt.hour == 21
 
             if is_weekday and is_work_hour:
-                item.category = ExpenseCategory.SKIP
+                item.category = ExpenseCategory.SKIP  # 双写：迁移期保留旧字段
+                item.lifecycle = Lifecycle.SKIPPED
+                item.skip_reason = SkipReason.FILTER
                 mark_skip_count += 1
 
         logger.info("美餐餐厅工作日18点标记为skip的item数量:{}".format(mark_skip_count))

--- a/bill_classifier/classifiers/meican_filter.py
+++ b/bill_classifier/classifiers/meican_filter.py
@@ -20,7 +20,7 @@ import re
 from typing import List
 
 from bill_item import BillItem
-from category import ExpenseCategory, Lifecycle, SkipReason
+from category import Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,6 @@ class MeicanFilter(Step):
             is_work_hour = dt.hour == 18 or dt.hour == 21
 
             if is_weekday and is_work_hour:
-                item.category = ExpenseCategory.SKIP  # 双写：迁移期保留旧字段
                 item.lifecycle = Lifecycle.SKIPPED
                 item.skip_reason = SkipReason.FILTER
                 mark_skip_count += 1

--- a/bill_classifier/classifiers/merge_payee.py
+++ b/bill_classifier/classifiers/merge_payee.py
@@ -22,7 +22,7 @@ import re
 from typing import List
 
 from bill_item import BillItem
-from category import ExpenseCategory, Lifecycle
+from category import Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -71,8 +71,8 @@ def _merge_one_rule(items: List[BillItem], rule: dict) -> List[BillItem]:
     last_items: List[BillItem] = []
 
     for item in items:
-        # 已被前置 step 处理过的 item 不参与合并（双写期：检查任一即可）
-        if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
+        # 已被前置 step 处理过的 item 不参与合并
+        if item.lifecycle != Lifecycle.UNPROCESSED:
             last_items.append(item)
             continue
 

--- a/bill_classifier/classifiers/merge_payee.py
+++ b/bill_classifier/classifiers/merge_payee.py
@@ -22,7 +22,7 @@ import re
 from typing import List
 
 from bill_item import BillItem
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,8 @@ def _merge_one_rule(items: List[BillItem], rule: dict) -> List[BillItem]:
     last_items: List[BillItem] = []
 
     for item in items:
-        if item.category != ExpenseCategory.UNKNOWN:
+        # 已被前置 step 处理过的 item 不参与合并（双写期：检查任一即可）
+        if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
             last_items.append(item)
             continue
 

--- a/bill_classifier/classifiers/merge_refund.py
+++ b/bill_classifier/classifiers/merge_refund.py
@@ -25,7 +25,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, BillType
-from category import ExpenseCategory, Lifecycle, SkipReason
+from category import Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,6 @@ class MergeRefund(Step):
         for item in items:
             if not item.order_id:
                 # 无 order_id 当前直接判 SKIP；TODO.md 已记账后续要修
-                item.category = ExpenseCategory.SKIP  # 双写
                 item.lifecycle = Lifecycle.SKIPPED
                 item.skip_reason = SkipReason.REFUND_NO_ORIG
                 merged_items.append(item)
@@ -81,7 +80,6 @@ class MergeRefund(Step):
                 debug_str += " - " + str(it.amount)
 
             if merged.amount == 0.0:
-                merged.category = ExpenseCategory.SKIP  # 双写
                 merged.lifecycle = Lifecycle.SKIPPED
                 merged.skip_reason = SkipReason.ZERO_AMOUNT
 

--- a/bill_classifier/classifiers/merge_refund.py
+++ b/bill_classifier/classifiers/merge_refund.py
@@ -25,7 +25,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, BillType
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,9 @@ class MergeRefund(Step):
         for item in items:
             if not item.order_id:
                 # 无 order_id 当前直接判 SKIP；TODO.md 已记账后续要修
-                item.category = ExpenseCategory.SKIP
+                item.category = ExpenseCategory.SKIP  # 双写
+                item.lifecycle = Lifecycle.SKIPPED
+                item.skip_reason = SkipReason.REFUND_NO_ORIG
                 merged_items.append(item)
                 logger.debug("退款记录丢失原始账单: {}".format(item))
                 continue
@@ -79,7 +81,9 @@ class MergeRefund(Step):
                 debug_str += " - " + str(it.amount)
 
             if merged.amount == 0.0:
-                merged.category = ExpenseCategory.SKIP
+                merged.category = ExpenseCategory.SKIP  # 双写
+                merged.lifecycle = Lifecycle.SKIPPED
+                merged.skip_reason = SkipReason.ZERO_AMOUNT
 
             merged_items.append(merged)
             logger.debug(

--- a/bill_classifier/classifiers/neighbor_inference.py
+++ b/bill_classifier/classifiers/neighbor_inference.py
@@ -26,7 +26,7 @@ import re
 from typing import List, Optional
 
 from bill_item import BillItem, ClassifyAlg
-from category import ExpenseCategory, Lifecycle
+from category import Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ class NeighborInference(Step):
         mark_count = 0
 
         for i, item in enumerate(items):
-            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED:
                 continue
             if not self._is_target(item):
                 continue

--- a/bill_classifier/classifiers/neighbor_inference.py
+++ b/bill_classifier/classifiers/neighbor_inference.py
@@ -26,7 +26,7 @@ import re
 from typing import List, Optional
 
 from bill_item import BillItem, ClassifyAlg
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ class NeighborInference(Step):
         mark_count = 0
 
         for i, item in enumerate(items):
-            if item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
                 continue
             if not self._is_target(item):
                 continue
@@ -103,6 +103,7 @@ class NeighborInference(Step):
             anchor = anchors[0]
             item.category = anchor.category
             item.classify_alg = ClassifyAlg.NEIGHBOR
+            item.lifecycle = Lifecycle.CLASSIFIED
             group_id = _make_group_id(anchor)
             item.neighbor_group = group_id
             anchor.neighbor_group = group_id

--- a/bill_classifier/classifiers/non_expense_skip.py
+++ b/bill_classifier/classifiers/non_expense_skip.py
@@ -21,7 +21,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, BillType
-from category import ExpenseCategory, Lifecycle, SkipReason
+from category import Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,6 @@ class NonExpenseSkip(Step):
                 continue
             if item.bill_type == BillType.EXPENSE:
                 continue
-            item.category = ExpenseCategory.SKIP  # 双写：迁移期保留旧字段
             item.lifecycle = Lifecycle.SKIPPED
             item.skip_reason = SkipReason.NON_EXPENSE
             count += 1

--- a/bill_classifier/classifiers/non_expense_skip.py
+++ b/bill_classifier/classifiers/non_expense_skip.py
@@ -1,0 +1,47 @@
+"""把 bill_type ∈ {INCOME, OTHER} 的条目标 SKIPPED + NON_EXPENSE。
+
+把这个职责从 `exact_match` 中拆出来：
+- 旧设计：exact_match 顺手把 bill_type != EXPENSE 的 item 标 SKIP，跟分类职责混在一起
+- 新设计：独立 step `non_expense_skip` 负责把非支出（INCOME / OTHER）标 SKIPPED，
+         分类 step 只关心 UNPROCESSED 的 EXPENSE
+
+实施位置：cross_month_unified 之后、exact_match 之前。
+理由：cross_month_unified 已经把"跨月退款"挑出来标 CROSS_MONTH_REFUND（这些是
+OTHER 类的合法条目，需要在右侧提醒），non_expense_skip 跑到它们时
+lifecycle != UNPROCESSED 会自动跳过，不会误覆盖。
+
+举例：
+- bill_type=INCOME（工资、转账收）→ SKIPPED + NON_EXPENSE
+- bill_type=OTHER（不计支出 / 余额宝收益）→ SKIPPED + NON_EXPENSE
+- bill_type=OTHER 但已被 cross_month_unified 标 CROSS_MONTH_REFUND → 跳过不动
+- bill_type=EXPENSE → 不动，留给 exact_match 等分类 step 处理
+"""
+
+import logging
+from typing import List
+
+from bill_item import BillItem, BillType
+from category import ExpenseCategory, Lifecycle, SkipReason
+from classifiers.base import Context, Step
+
+logger = logging.getLogger(__name__)
+
+
+class NonExpenseSkip(Step):
+    """非支出条目（INCOME / OTHER）标 SKIPPED + NON_EXPENSE。"""
+
+    name = "non_expense_skip"
+
+    def run(self, items: List[BillItem], ctx: Context) -> List[BillItem]:
+        count = 0
+        for item in items:
+            if item.lifecycle != Lifecycle.UNPROCESSED:
+                continue
+            if item.bill_type == BillType.EXPENSE:
+                continue
+            item.category = ExpenseCategory.SKIP  # 双写：迁移期保留旧字段
+            item.lifecycle = Lifecycle.SKIPPED
+            item.skip_reason = SkipReason.NON_EXPENSE
+            count += 1
+        logger.info("non_expense_skip 标记数:%d", count)
+        return items

--- a/bill_classifier/classifiers/regex_match.py
+++ b/bill_classifier/classifiers/regex_match.py
@@ -25,7 +25,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, ClassifyAlg
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class RegexMatch(Step):
 
         mark_count = 0
         for item in items:
-            if item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
                 continue
 
             matched = False
@@ -55,6 +55,7 @@ class RegexMatch(Step):
                 if needle in item.item_name:
                     item.category = category
                     item.classify_alg = ClassifyAlg.REGULAR
+                    item.lifecycle = Lifecycle.CLASSIFIED
                     mark_count += 1
                     matched = True
                     break
@@ -65,6 +66,7 @@ class RegexMatch(Step):
                 if needle in item.payee:
                     item.category = category
                     item.classify_alg = ClassifyAlg.REGULAR
+                    item.lifecycle = Lifecycle.CLASSIFIED
                     mark_count += 1
                     break
 

--- a/bill_classifier/classifiers/regex_match.py
+++ b/bill_classifier/classifiers/regex_match.py
@@ -25,7 +25,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, ClassifyAlg
-from category import ExpenseCategory, Lifecycle
+from category import Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class RegexMatch(Step):
 
         mark_count = 0
         for item in items:
-            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED:
                 continue
 
             matched = False

--- a/bill_classifier/classifiers/skip_keywords.py
+++ b/bill_classifier/classifiers/skip_keywords.py
@@ -16,7 +16,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem
-from category import ExpenseCategory, Lifecycle, SkipReason
+from category import Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -38,10 +38,9 @@ class SkipKeywords(Step):
     def run(self, items: List[BillItem], ctx: Context) -> List[BillItem]:
         count = 0
         for item in items:
-            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED:
                 continue
             if item.item_name in self._names:
-                item.category = ExpenseCategory.SKIP  # 双写
                 item.lifecycle = Lifecycle.SKIPPED
                 item.skip_reason = SkipReason.BLACKLIST
                 count += 1

--- a/bill_classifier/classifiers/skip_keywords.py
+++ b/bill_classifier/classifiers/skip_keywords.py
@@ -16,7 +16,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -38,10 +38,12 @@ class SkipKeywords(Step):
     def run(self, items: List[BillItem], ctx: Context) -> List[BillItem]:
         count = 0
         for item in items:
-            if item.category != ExpenseCategory.UNKNOWN:
+            if item.lifecycle != Lifecycle.UNPROCESSED or item.category != ExpenseCategory.UNKNOWN:
                 continue
             if item.item_name in self._names:
-                item.category = ExpenseCategory.SKIP
+                item.category = ExpenseCategory.SKIP  # 双写
+                item.lifecycle = Lifecycle.SKIPPED
+                item.skip_reason = SkipReason.BLACKLIST
                 count += 1
         logger.info("extra skip item size:{}".format(count))
         return items

--- a/bill_classifier/classifiers/taobao_balance_merge.py
+++ b/bill_classifier/classifiers/taobao_balance_merge.py
@@ -39,7 +39,7 @@ import logging
 from typing import Dict, List, Optional
 
 from bill_item import BillItem, BillType
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -156,7 +156,9 @@ class TaobaoBalanceMerge(Step):
             primary.amount = net
             primary.taobao_balance_extra = f"购物金消费余额: {net:.2f}"
             if net == 0:
-                primary.category = ExpenseCategory.SKIP
+                primary.category = ExpenseCategory.SKIP  # 双写
+                primary.lifecycle = Lifecycle.SKIPPED
+                primary.skip_reason = SkipReason.ZERO_AMOUNT
             merged.append(primary)
 
             logger.info(

--- a/bill_classifier/classifiers/taobao_balance_merge.py
+++ b/bill_classifier/classifiers/taobao_balance_merge.py
@@ -39,7 +39,7 @@ import logging
 from typing import Dict, List, Optional
 
 from bill_item import BillItem, BillType
-from category import ExpenseCategory, Lifecycle, SkipReason
+from category import Lifecycle, SkipReason
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -156,7 +156,6 @@ class TaobaoBalanceMerge(Step):
             primary.amount = net
             primary.taobao_balance_extra = f"购物金消费余额: {net:.2f}"
             if net == 0:
-                primary.category = ExpenseCategory.SKIP  # 双写
                 primary.lifecycle = Lifecycle.SKIPPED
                 primary.skip_reason = SkipReason.ZERO_AMOUNT
             merged.append(primary)

--- a/bill_classifier/classifiers/wet_market.py
+++ b/bill_classifier/classifiers/wet_market.py
@@ -60,7 +60,7 @@ class WetMarket(Step):
             for j in range(s, e + 1):
                 if j == i:
                     continue
-                if items[j].lifecycle == Lifecycle.UNPROCESSED and items[j].category == ExpenseCategory.UNKNOWN:
+                if items[j].lifecycle == Lifecycle.UNPROCESSED:
                     items[j].category = ExpenseCategory.BUY_VEGETABLES
                     items[j].classify_alg = ClassifyAlg.WET_MARKET
                     items[j].lifecycle = Lifecycle.CLASSIFIED

--- a/bill_classifier/classifiers/wet_market.py
+++ b/bill_classifier/classifiers/wet_market.py
@@ -27,7 +27,7 @@ import logging
 from typing import List
 
 from bill_item import BillItem, ClassifyAlg
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -60,9 +60,10 @@ class WetMarket(Step):
             for j in range(s, e + 1):
                 if j == i:
                     continue
-                if items[j].category == ExpenseCategory.UNKNOWN:
+                if items[j].lifecycle == Lifecycle.UNPROCESSED and items[j].category == ExpenseCategory.UNKNOWN:
                     items[j].category = ExpenseCategory.BUY_VEGETABLES
                     items[j].classify_alg = ClassifyAlg.WET_MARKET
+                    items[j].lifecycle = Lifecycle.CLASSIFIED
                     mark_count += 1
 
         logger.debug("时间段买菜标记 item size:{}".format(mark_count))

--- a/bill_classifier/feishu.py
+++ b/bill_classifier/feishu.py
@@ -233,14 +233,14 @@ class FeishuSheetAPI:
         for item in bill_item_list:
             line_data = [
                 item.amount,
-                item.category.to_str(),
+                item.category_display(),
                 item.payee,
                 item.item_name,
                 item.bill_type.value,
                 timestamp2str(item.bill_time),
                 item.bill_source,
                 item.owner,
-                item.classify_alg.to_str()
+                item.classify_alg_display(),
             ]
 
             data['valueRange']['values'].append(line_data)

--- a/bill_classifier/main.py
+++ b/bill_classifier/main.py
@@ -10,7 +10,7 @@ import argparse
 
 from feishu import FeishuSheetAPI
 from feishu_auth import FeishuAuthError, get_valid_user_access_token
-from category import ExpenseCategory, Lifecycle
+from category import Lifecycle
 from bill_item import BillType, ClassifyAlg
 from bill import AliPayBill, WeChatBill
 from bill_config import BillConfig
@@ -77,9 +77,9 @@ def record_to_feishu(feishu_config, bill_item_dict):
 def check_unknown_items(bill_item_list):
     count = 0
     for item in bill_item_list:
-        if item.category == ExpenseCategory.UNKNOWN:
+        if item.lifecycle == Lifecycle.UNPROCESSED:
             count += 1
-    logging.debug("unknown category item size:{}".format(count))
+    logging.debug("unprocessed item size:{}".format(count))
 
 def debug_bill_item_list(prefix, bill_item_list):
     logging.info("-------{} size:{}--------".format(prefix, len(bill_item_list)))

--- a/bill_classifier/main.py
+++ b/bill_classifier/main.py
@@ -10,7 +10,7 @@ import argparse
 
 from feishu import FeishuSheetAPI
 from feishu_auth import FeishuAuthError, get_valid_user_access_token
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from bill_item import BillType, ClassifyAlg
 from bill import AliPayBill, WeChatBill
 from bill_config import BillConfig
@@ -114,6 +114,69 @@ def _reorder_with_neighbor_groups(items):
     return out
 
 
+# CLASSIFIED 类的展示顺序（按 classify_alg 二级分组）
+_CLASSIFIED_ALG_ORDER = (
+    ClassifyAlg.MATCH,
+    ClassifyAlg.REGULAR,
+    ClassifyAlg.WET_MARKET,
+    ClassifyAlg.NEIGHBOR,
+    ClassifyAlg.GPT,
+)
+
+
+def split_for_output(bill_item_list):
+    """按 lifecycle 一级 + classify_alg 二级分流，返回 (主表 list, 收入 list, 右侧提醒 list)。
+
+    主表展示顺序：
+        CLASSIFIED 按 classify_alg：MATCH → REGULAR → WET_MARKET → NEIGHBOR → GPT
+        → UNPROCESSED（等人工标）
+        → CROSS_MONTH_REFUND（跨月退款，左侧主表保留 + 右侧也展示一份）
+        → SKIPPED（被各种 reason 跳过的）
+        → INCOME 类（最底部，按 bill_type=INCOME 单独分组）
+
+    最后对主表应用 neighbor_group 紧邻重排（方案 A）。
+    右侧提醒：所有挂了 cross_month_origin 的条目（这些条目同时仍在左侧主表）。
+    """
+    classified_buckets = {alg: [] for alg in _CLASSIFIED_ALG_ORDER}
+    unprocessed_data = []
+    cross_month_data = []
+    skipped_data = []
+    income_data = []
+
+    for it in bill_item_list:
+        # bill_type=INCOME 的 item 已被 non_expense_skip 标 SKIPPED；
+        # 但视觉上分组为"收入"放底部，所以这里优先按 bill_type 判断。
+        if it.bill_type == BillType.INCOME:
+            income_data.append(it)
+            continue
+        if it.lifecycle == Lifecycle.CLASSIFIED:
+            bucket = classified_buckets.get(it.classify_alg)
+            if bucket is not None:
+                bucket.append(it)
+            else:
+                # 防御：未知 classify_alg，归到 unprocessed
+                unprocessed_data.append(it)
+        elif it.lifecycle == Lifecycle.CROSS_MONTH_REFUND:
+            cross_month_data.append(it)
+        elif it.lifecycle == Lifecycle.SKIPPED:
+            skipped_data.append(it)
+        else:  # UNPROCESSED
+            unprocessed_data.append(it)
+
+    main_data = []
+    for alg in _CLASSIFIED_ALG_ORDER:
+        main_data.extend(classified_buckets[alg])
+    main_data.extend(unprocessed_data)
+    main_data.extend(cross_month_data)
+    main_data.extend(skipped_data)
+    main_data.extend(income_data)
+
+    main_data = _reorder_with_neighbor_groups(main_data)
+
+    right_extra = [it for it in bill_item_list if getattr(it, 'cross_month_origin', None)]
+    return main_data, income_data, right_extra
+
+
 def load_bill_file(config):
     i = 1
     bill_files = []
@@ -178,57 +241,15 @@ if __name__ == "__main__":
     logging.info("标记类型后 item:{}".format(len(bill_item_list)))
 
     # 拆分数据。原则：
-    #   左侧（主表）= 所有账单条目，除了已经被合并的（merge_payee/merge_refund 已处理）
-    #     才不会出现，单条账单不因为"也要在右侧出现"而被排除
-    #   右侧（补充列）= 独立的提醒块，从左侧条目额外摘出展示，不影响左侧完整性
-    income_data = []
-    expense_data = []
-    other_data = []
-    skip_data = []
-    unknown_data = []
-    gpt_data = []
-    regular_data = []
-    wet_market_data = []
-    # 右侧提醒块：跨月退款关联到原支出的条目（item 同时仍在左侧主表）
-    # 后续可加：未退款预付款提醒（TODO）
-    right_extra_data = [it for it in bill_item_list if getattr(it, 'cross_month_origin', None)]
-
-    for bill_item in bill_item_list:
-        if bill_item.bill_type == BillType.INCOME:
-            income_data.append(bill_item)
-        elif bill_item.bill_type == BillType.OTHER:
-            other_data.append(bill_item)
-        else:  # EXPENSE
-            if bill_item.category == ExpenseCategory.UNKNOWN:
-                unknown_data.append(bill_item)
-            elif bill_item.classify_alg == ClassifyAlg.GPT:
-                gpt_data.append(bill_item)
-            elif bill_item.classify_alg == ClassifyAlg.REGULAR:
-                regular_data.append(bill_item)
-            elif bill_item.classify_alg == ClassifyAlg.WET_MARKET:
-                wet_market_data.append(bill_item)
-            elif bill_item.category == ExpenseCategory.BUY_VEGETABLES:
-                wet_market_data.append(bill_item)
-            elif bill_item.category == ExpenseCategory.SKIP:
-                skip_data.append(bill_item)
-            else:
-                if bill_item.amount == 0.0:
-                    skip_data.append(bill_item)
-                else:
-                    expense_data.append(bill_item)
-
-    expense_data.extend(regular_data)
-    expense_data.extend(wet_market_data)
-    expense_data.extend(gpt_data)
-    expense_data.extend(unknown_data)
-    expense_data.extend(other_data)
-    expense_data.extend(skip_data)
-    expense_data.extend(income_data)
-    # 策略 4：同 neighbor_group 的 item 紧邻输出（方案 A）
-    expense_data = _reorder_with_neighbor_groups(expense_data)
+    #   左侧（主表）= 所有账单条目（按 lifecycle 一级分流 + CLASSIFIED 内按
+    #     classify_alg 二级分组）。只有在 merge_payee / merge_refund /
+    #     taobao_balance_merge 中"被合并掉"的条目才会从 list 里移除，
+    #     单条账单不因为"也要在右侧出现"而被排除。
+    #   右侧（补充列）= 独立的提醒块，从左侧条目额外摘出展示，不影响左侧完整性。
+    main_data, income_data, right_extra_data = split_for_output(bill_item_list)
 
     bill_item_dict = {
-        "expense": expense_data,
+        "expense": main_data,
         "income": income_data,
         "right_extra": right_extra_data,
     }

--- a/tests/test_exact_match.py
+++ b/tests/test_exact_match.py
@@ -1,5 +1,5 @@
 from bill_item import BillType, ClassifyAlg
-from category import CategoryInfo, ExpenseCategory
+from category import CategoryInfo, ExpenseCategory, Lifecycle
 from classifiers.exact_match import ExactMatch
 
 from helpers import make_context, make_item
@@ -30,25 +30,25 @@ def test_payee_hit_when_item_name_miss():
 def test_non_expense_marked_skip():
     item = make_item(item_name="工资", bill_type=BillType.INCOME)
     ExactMatch().run([item], make_context(info=_info()))
-    assert item.category == ExpenseCategory.SKIP
+    assert item.lifecycle == Lifecycle.SKIPPED
 
 
 def test_already_categorized_skipped():
     item = make_item(item_name="地铁单程票")
-    item.category = ExpenseCategory.SKIP
+    item.lifecycle = Lifecycle.SKIPPED
     ExactMatch().run([item], make_context(info=_info()))
-    assert item.category == ExpenseCategory.SKIP
+    assert item.lifecycle == Lifecycle.SKIPPED
 
 
 def test_loader_failure_only_skips_this_step():
     """飞书 IO 失败时，只本 step 跳过，item 状态不变。"""
     item = make_item(item_name="地铁单程票")
     ExactMatch().run([item], make_context(info=None, ok=False))
-    assert item.category == ExpenseCategory.UNKNOWN
-    assert item.classify_alg == ClassifyAlg.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED
+    assert item.classify_alg is None
 
 
 def test_no_match_leaves_unknown():
     item = make_item(item_name="未知", payee="未知")
     ExactMatch().run([item], make_context(info=_info()))
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 from bill_item import ClassifyAlg
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.gpt import GPTStep
 
 from helpers import FakeGPTClassifier, make_context, make_item
@@ -24,11 +24,11 @@ def test_unknown_item_classified_via_gpt():
 
 def test_already_categorized_skipped_no_call():
     item = make_item(item_name="x", payee="y")
-    item.category = ExpenseCategory.SKIP
+    item.lifecycle = Lifecycle.SKIPPED
     fake = FakeGPTClassifier(default="餐饮")
     GPTStep().run([item], make_context(gpt_classifier=fake, bill_config=_bill_config()))
     assert fake.calls == []
-    assert item.category == ExpenseCategory.SKIP
+    assert item.lifecycle == Lifecycle.SKIPPED
 
 
 def test_meituan_payee_skipped():
@@ -37,8 +37,8 @@ def test_meituan_payee_skipped():
     fake = FakeGPTClassifier(default="餐饮")
     GPTStep().run([a, b], make_context(gpt_classifier=fake, bill_config=_bill_config()))
     assert fake.calls == []
-    assert a.category == ExpenseCategory.UNKNOWN
-    assert b.category == ExpenseCategory.UNKNOWN
+    assert a.lifecycle == Lifecycle.UNPROCESSED
+    assert b.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_jd_with_order_id_in_name_skipped():
@@ -47,7 +47,7 @@ def test_jd_with_order_id_in_name_skipped():
     fake = FakeGPTClassifier(default="餐饮")
     GPTStep().run([a, b], make_context(gpt_classifier=fake, bill_config=_bill_config()))
     assert len(fake.calls) == 1
-    assert a.category == ExpenseCategory.UNKNOWN
+    assert a.lifecycle == Lifecycle.UNPROCESSED
     assert b.category == ExpenseCategory.CATERING
 
 
@@ -63,17 +63,17 @@ def test_unknown_response_text_does_not_set_category():
     item = make_item(item_name="x", payee="y")
     fake = FakeGPTClassifier(default="不是合法分类的随便字符串")
     GPTStep().run([item], make_context(gpt_classifier=fake, bill_config=_bill_config()))
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_empty_response_does_not_set_category():
     item = make_item(item_name="x", payee="y")
     fake = FakeGPTClassifier(default="")
     GPTStep().run([item], make_context(gpt_classifier=fake, bill_config=_bill_config()))
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_no_classifier_skips_step():
     item = make_item(item_name="x", payee="y")
     GPTStep().run([item], make_context(gpt_classifier=None, bill_config=_bill_config()))
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED

--- a/tests/test_meican_filter.py
+++ b/tests/test_meican_filter.py
@@ -1,7 +1,7 @@
 import datetime
 
 from bill_item import BillType
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.meican_filter import MeicanFilter
 
 from helpers import make_context, make_item
@@ -15,19 +15,19 @@ def _ts(year=2025, month=1, day=6, hour=18, minute=0):
 def test_weekday_18_marked_skip():
     item = make_item(payee="高德地图总部-美餐餐厅A区", bill_time=_ts(hour=18))
     MeicanFilter().run([item], make_context())
-    assert item.category == ExpenseCategory.SKIP
+    assert item.lifecycle == Lifecycle.SKIPPED
 
 
 def test_weekday_21_marked_skip():
     item = make_item(payee="高德地图总部-美餐餐厅B区", bill_time=_ts(hour=21))
     MeicanFilter().run([item], make_context())
-    assert item.category == ExpenseCategory.SKIP
+    assert item.lifecycle == Lifecycle.SKIPPED
 
 
 def test_weekday_19_not_marked():
     item = make_item(payee="高德地图总部-美餐餐厅A区", bill_time=_ts(hour=19))
     MeicanFilter().run([item], make_context())
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_weekend_18_not_marked():
@@ -36,13 +36,13 @@ def test_weekend_18_not_marked():
         bill_time=_ts(year=2025, month=1, day=11, hour=18),  # 周六
     )
     MeicanFilter().run([item], make_context())
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_other_payee_untouched():
     item = make_item(payee="星巴克", bill_time=_ts(hour=18))
     MeicanFilter().run([item], make_context())
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_returns_same_list_object():
@@ -59,4 +59,4 @@ def test_income_in_window_also_marked_when_payee_matches():
         bill_time=_ts(hour=18),
     )
     MeicanFilter().run([item], make_context())
-    assert item.category == ExpenseCategory.SKIP
+    assert item.lifecycle == Lifecycle.SKIPPED

--- a/tests/test_merge_payee.py
+++ b/tests/test_merge_payee.py
@@ -1,4 +1,4 @@
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.merge_payee import MergePayee
 
 from helpers import make_context, make_item
@@ -36,7 +36,7 @@ def test_already_categorized_items_skipped():
     """非 UNKNOWN 的 item 不参与合并。"""
     a = make_item(item_name="余额宝-X收益发放", amount=1, owner="A")
     b = make_item(item_name="余额宝-Y收益发放", amount=2, owner="A")
-    b.category = ExpenseCategory.SKIP
+    b.lifecycle = Lifecycle.SKIPPED
     out = MergePayee().run([a, b], make_context())
     assert len(out) == 2
     # b 原样保留

--- a/tests/test_merge_refund.py
+++ b/tests/test_merge_refund.py
@@ -1,5 +1,5 @@
 from bill_item import BillType
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.merge_refund import MergeRefund
 
 from helpers import make_context, make_item
@@ -9,7 +9,7 @@ def test_no_order_id_marked_skip():
     item = make_item(amount=10, order_id="")
     out = MergeRefund().run([item], make_context())
     assert len(out) == 1
-    assert out[0].category == ExpenseCategory.SKIP
+    assert out[0].lifecycle == Lifecycle.SKIPPED
 
 
 def test_single_item_with_order_id_passthrough():
@@ -17,7 +17,7 @@ def test_single_item_with_order_id_passthrough():
     out = MergeRefund().run([item], make_context())
     assert len(out) == 1
     assert out[0] is item
-    assert out[0].category == ExpenseCategory.UNKNOWN
+    assert out[0].lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_expense_minus_refund_zero_marks_skip():
@@ -31,7 +31,7 @@ def test_expense_minus_refund_zero_marks_skip():
     out = MergeRefund().run([expense, refund], make_context())
     assert len(out) == 1
     assert out[0].amount == 0
-    assert out[0].category == ExpenseCategory.SKIP
+    assert out[0].lifecycle == Lifecycle.SKIPPED
 
 
 def test_partial_refund_keeps_remainder():
@@ -45,7 +45,7 @@ def test_partial_refund_keeps_remainder():
     out = MergeRefund().run([expense, refund], make_context())
     assert len(out) == 1
     assert out[0].amount == 15
-    assert out[0].category == ExpenseCategory.UNKNOWN
+    assert out[0].lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_two_expenses_same_order_id_summed():

--- a/tests/test_neighbor_inference.py
+++ b/tests/test_neighbor_inference.py
@@ -1,5 +1,5 @@
 from bill_item import ClassifyAlg
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.neighbor_inference import NeighborInference
 
 from helpers import make_context, make_item
@@ -42,8 +42,8 @@ def test_no_match_anchor_in_window_keeps_unknown():
     target = _meituan_unknown()
     far_anchor = _match_anchor(T0 + 301)  # 超出 5 分钟
     NeighborInference().run([target, far_anchor], make_context())
-    assert target.category == ExpenseCategory.UNKNOWN
-    assert target.classify_alg == ClassifyAlg.UNKNOWN
+    assert target.lifecycle == Lifecycle.UNPROCESSED
+    assert target.classify_alg is None
     assert target.neighbor_group is None
 
 
@@ -52,8 +52,8 @@ def test_two_match_anchors_in_window_keeps_unknown():
     a1 = _match_anchor(T0 + 60, category=ExpenseCategory.CATERING)
     a2 = _match_anchor(T0 + 200, category=ExpenseCategory.DAILY_EXPENSES)
     NeighborInference().run([target, a1, a2], make_context())
-    assert target.category == ExpenseCategory.UNKNOWN
-    assert target.classify_alg == ClassifyAlg.UNKNOWN
+    assert target.lifecycle == Lifecycle.UNPROCESSED
+    assert target.classify_alg is None
 
 
 def test_anchor_in_past_does_not_count_one_directional():
@@ -61,7 +61,7 @@ def test_anchor_in_past_does_not_count_one_directional():
     early_anchor = _match_anchor(T0 - 60)
     target = _meituan_unknown(t=T0)
     NeighborInference().run([early_anchor, target], make_context())
-    assert target.category == ExpenseCategory.UNKNOWN
+    assert target.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_anchor_at_window_boundary_inclusive():
@@ -76,7 +76,7 @@ def test_anchor_at_window_boundary_inclusive():
     target2 = _meituan_unknown(t=2 * T0)
     over = _match_anchor(2 * T0 + 301)
     NeighborInference().run([target2, over], make_context())
-    assert target2.category == ExpenseCategory.UNKNOWN
+    assert target2.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_non_match_anchors_ignored():
@@ -87,7 +87,7 @@ def test_non_match_anchors_ignored():
         anchor = _match_anchor(T0 + 100)
         anchor.classify_alg = alg  # 改成非 MATCH 锚点
         NeighborInference().run([target, anchor], make_context())
-        assert target.category == ExpenseCategory.UNKNOWN, f"alg={alg} 不应触发"
+        assert target.lifecycle == Lifecycle.UNPROCESSED, f"alg={alg} 不应触发"
 
 
 def test_non_low_info_payee_skipped():
@@ -95,7 +95,7 @@ def test_non_low_info_payee_skipped():
     target = make_item(payee="星巴克", item_name="拿铁", bill_time=T0)
     anchor = _match_anchor(T0 + 60)
     NeighborInference().run([target, anchor], make_context())
-    assert target.category == ExpenseCategory.UNKNOWN
+    assert target.lifecycle == Lifecycle.UNPROCESSED
     assert target.neighbor_group is None
 
 
@@ -103,6 +103,7 @@ def test_already_classified_skipped():
     """已分类的 item 即使是低信息量 payee 也不被覆盖。"""
     target = _meituan_unknown()
     target.category = ExpenseCategory.CATERING  # 假设之前 step 已分
+    target.lifecycle = Lifecycle.CLASSIFIED
     anchor = _match_anchor(T0 + 60, category=ExpenseCategory.MEDICAL)
     NeighborInference().run([target, anchor], make_context())
     # 不被覆盖
@@ -167,4 +168,4 @@ def test_empty_or_single_item_list():
     NeighborInference().run([], make_context())
     one = _meituan_unknown()
     NeighborInference().run([one], make_context())
-    assert one.category == ExpenseCategory.UNKNOWN
+    assert one.lifecycle == Lifecycle.UNPROCESSED

--- a/tests/test_non_expense_skip.py
+++ b/tests/test_non_expense_skip.py
@@ -1,0 +1,84 @@
+from bill_item import BillType
+from category import ExpenseCategory, Lifecycle, SkipReason
+from classifiers.non_expense_skip import NonExpenseSkip
+
+from helpers import make_context, make_item
+
+
+def test_expense_item_unchanged():
+    item = make_item(bill_type=BillType.EXPENSE)
+    NonExpenseSkip().run([item], make_context())
+    assert item.lifecycle == Lifecycle.UNPROCESSED
+    assert item.skip_reason is None
+    assert item.category == ExpenseCategory.UNKNOWN
+
+
+def test_income_item_marked_skipped():
+    item = make_item(bill_type=BillType.INCOME)
+    NonExpenseSkip().run([item], make_context())
+    assert item.lifecycle == Lifecycle.SKIPPED
+    assert item.skip_reason == SkipReason.NON_EXPENSE
+    # 双写：旧 category 字段也设为 SKIP
+    assert item.category == ExpenseCategory.SKIP
+
+
+def test_other_item_marked_skipped():
+    item = make_item(bill_type=BillType.OTHER)
+    NonExpenseSkip().run([item], make_context())
+    assert item.lifecycle == Lifecycle.SKIPPED
+    assert item.skip_reason == SkipReason.NON_EXPENSE
+    assert item.category == ExpenseCategory.SKIP
+
+
+def test_already_skipped_not_overridden():
+    """已被前面 step 标 SKIPPED 的不被覆盖。"""
+    item = make_item(bill_type=BillType.OTHER)
+    item.lifecycle = Lifecycle.SKIPPED
+    item.skip_reason = SkipReason.FILTER  # 假设之前 meican_filter 标的
+    item.category = ExpenseCategory.SKIP
+    NonExpenseSkip().run([item], make_context())
+    # skip_reason 不被改写
+    assert item.skip_reason == SkipReason.FILTER
+
+
+def test_cross_month_refund_not_overridden():
+    """已被 cross_month_unified 标 CROSS_MONTH_REFUND 的不被覆盖（即使 bill_type=OTHER）。"""
+    item = make_item(bill_type=BillType.OTHER)
+    item.lifecycle = Lifecycle.CROSS_MONTH_REFUND
+    item.cross_month_origin = {"payee": "x", "amount": 1.0, "bill_time": 0,
+                                "item_name": "y", "order_id": "", "bill_source": "wechat", "owner": ""}
+    NonExpenseSkip().run([item], make_context())
+    assert item.lifecycle == Lifecycle.CROSS_MONTH_REFUND
+    assert item.skip_reason is None
+    assert item.cross_month_origin is not None
+
+
+def test_classified_not_overridden():
+    """理论上 non_expense_skip 跑在分类 step 前，但防御式测试。"""
+    item = make_item(bill_type=BillType.EXPENSE)
+    item.lifecycle = Lifecycle.CLASSIFIED
+    item.category = ExpenseCategory.CATERING
+    NonExpenseSkip().run([item], make_context())
+    assert item.lifecycle == Lifecycle.CLASSIFIED
+    assert item.category == ExpenseCategory.CATERING
+
+
+def test_mixed_bill_types_correctly_split():
+    expense = make_item(bill_type=BillType.EXPENSE)
+    income = make_item(bill_type=BillType.INCOME)
+    other = make_item(bill_type=BillType.OTHER)
+    NonExpenseSkip().run([expense, income, other], make_context())
+    assert expense.lifecycle == Lifecycle.UNPROCESSED
+    assert income.lifecycle == Lifecycle.SKIPPED
+    assert other.lifecycle == Lifecycle.SKIPPED
+
+
+def test_step_registered_in_pipeline():
+    from classifiers import DEFAULT_STEPS, STEP_REGISTRY
+    assert "non_expense_skip" in DEFAULT_STEPS
+    assert "non_expense_skip" in STEP_REGISTRY
+    # 位置：cross_month_unified 之后、exact_match 之前
+    idx_cm = DEFAULT_STEPS.index("cross_month_unified")
+    idx_nes = DEFAULT_STEPS.index("non_expense_skip")
+    idx_em = DEFAULT_STEPS.index("exact_match")
+    assert idx_cm < idx_nes < idx_em

--- a/tests/test_non_expense_skip.py
+++ b/tests/test_non_expense_skip.py
@@ -10,7 +10,6 @@ def test_expense_item_unchanged():
     NonExpenseSkip().run([item], make_context())
     assert item.lifecycle == Lifecycle.UNPROCESSED
     assert item.skip_reason is None
-    assert item.category == ExpenseCategory.UNKNOWN
 
 
 def test_income_item_marked_skipped():
@@ -18,8 +17,6 @@ def test_income_item_marked_skipped():
     NonExpenseSkip().run([item], make_context())
     assert item.lifecycle == Lifecycle.SKIPPED
     assert item.skip_reason == SkipReason.NON_EXPENSE
-    # 双写：旧 category 字段也设为 SKIP
-    assert item.category == ExpenseCategory.SKIP
 
 
 def test_other_item_marked_skipped():
@@ -27,7 +24,6 @@ def test_other_item_marked_skipped():
     NonExpenseSkip().run([item], make_context())
     assert item.lifecycle == Lifecycle.SKIPPED
     assert item.skip_reason == SkipReason.NON_EXPENSE
-    assert item.category == ExpenseCategory.SKIP
 
 
 def test_already_skipped_not_overridden():
@@ -35,7 +31,6 @@ def test_already_skipped_not_overridden():
     item = make_item(bill_type=BillType.OTHER)
     item.lifecycle = Lifecycle.SKIPPED
     item.skip_reason = SkipReason.FILTER  # 假设之前 meican_filter 标的
-    item.category = ExpenseCategory.SKIP
     NonExpenseSkip().run([item], make_context())
     # skip_reason 不被改写
     assert item.skip_reason == SkipReason.FILTER

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pipeline
 from bill_item import ClassifyAlg
-from category import CategoryInfo, ExpenseCategory
+from category import CategoryInfo, ExpenseCategory, Lifecycle
 from classifiers.base import CategoryInfoLoader
 
 from helpers import FakeGPTClassifier, make_item
@@ -52,7 +52,7 @@ def test_disabled_gpt_step_leaves_unknown():
         category_info_loader=CategoryInfoLoader(fetch=lambda: (True, _info_with_metro_match())),
         gpt_classifier_factory=lambda: fake_gpt,
     )
-    assert out[0].category == ExpenseCategory.UNKNOWN
+    assert out[0].lifecycle == Lifecycle.UNPROCESSED
     assert fake_gpt.calls == []
 
 

--- a/tests/test_regex_match.py
+++ b/tests/test_regex_match.py
@@ -1,5 +1,5 @@
 from bill_item import ClassifyAlg
-from category import CategoryInfo, ExpenseCategory
+from category import CategoryInfo, ExpenseCategory, Lifecycle
 from classifiers.regex_match import RegexMatch
 
 from helpers import make_context, make_item
@@ -29,15 +29,15 @@ def test_payee_substring_hit_when_item_miss():
 
 def test_already_categorized_skipped():
     item = make_item(item_name="地铁充值")
-    item.category = ExpenseCategory.SKIP
+    item.lifecycle = Lifecycle.SKIPPED
     RegexMatch().run([item], make_context(info=_info()))
-    assert item.category == ExpenseCategory.SKIP
+    assert item.lifecycle == Lifecycle.SKIPPED
 
 
 def test_loader_failure_only_skips_this_step():
     item = make_item(item_name="地铁充值")
     RegexMatch().run([item], make_context(info=None, ok=False))
-    assert item.category == ExpenseCategory.UNKNOWN
+    assert item.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_first_match_wins():

--- a/tests/test_skip_keywords.py
+++ b/tests/test_skip_keywords.py
@@ -1,4 +1,4 @@
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.skip_keywords import SkipKeywords
 
 from helpers import make_context, make_item
@@ -9,9 +9,9 @@ def test_default_blacklist_marks_skip():
     b = make_item(item_name="转账备注:微信转账")
     c = make_item(item_name="正常商品")
     SkipKeywords().run([a, b, c], make_context())
-    assert a.category == ExpenseCategory.SKIP
-    assert b.category == ExpenseCategory.SKIP
-    assert c.category == ExpenseCategory.UNKNOWN
+    assert a.lifecycle == Lifecycle.SKIPPED
+    assert b.lifecycle == Lifecycle.SKIPPED
+    assert c.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_already_categorized_skipped():
@@ -24,4 +24,4 @@ def test_already_categorized_skipped():
 def test_custom_names():
     a = make_item(item_name="自定义跳过")
     SkipKeywords(names=["自定义跳过"]).run([a], make_context())
-    assert a.category == ExpenseCategory.SKIP
+    assert a.lifecycle == Lifecycle.SKIPPED

--- a/tests/test_taobao_balance_merge.py
+++ b/tests/test_taobao_balance_merge.py
@@ -1,5 +1,5 @@
 from bill_item import BillType
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.taobao_balance_merge import (
     TaobaoBalanceMerge,
     _extract_core_order_id,
@@ -93,7 +93,7 @@ def test_recharge_full_refund_marks_skip():
     assert len(out) == 1
     assert out[0] is rc  # 保留充值条目作为合并载体
     assert out[0].amount == 0
-    assert out[0].category == ExpenseCategory.SKIP
+    assert out[0].lifecycle == Lifecycle.SKIPPED
     assert out[0].taobao_balance_extra == "购物金消费余额: 0.00"
 
 
@@ -109,7 +109,7 @@ def test_recharge_partial_refund_keeps_net():
     # 余额说明里也是净额
     assert out[0].taobao_balance_extra == "购物金消费余额: 869.00"
     # 净额非 0 不打 SKIP
-    assert out[0].category == ExpenseCategory.UNKNOWN
+    assert out[0].lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_only_refund_no_recharge_left_alone():

--- a/tests/test_wet_market.py
+++ b/tests/test_wet_market.py
@@ -1,5 +1,5 @@
 from bill_item import ClassifyAlg
-from category import ExpenseCategory
+from category import ExpenseCategory, Lifecycle
 from classifiers.wet_market import WetMarket
 
 from helpers import make_context, make_item
@@ -48,7 +48,7 @@ def test_unknown_outside_window_not_marked():
     far = make_item(item_name="远前", bill_time=ANCHOR_T - WINDOW - 100)
     items = [far, _anchor(), make_item(bill_time=ANCHOR_T + 99999)]
     WetMarket().run(items, make_context())
-    assert far.category == ExpenseCategory.UNKNOWN
+    assert far.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_anchor_with_non_match_alg_does_not_trigger():
@@ -57,12 +57,13 @@ def test_anchor_with_non_match_alg_does_not_trigger():
     anchor.classify_alg = ClassifyAlg.REGULAR
     near = make_item(item_name="附近", bill_time=ANCHOR_T - 100)
     WetMarket().run([near, anchor], make_context())
-    assert near.category == ExpenseCategory.UNKNOWN
+    assert near.lifecycle == Lifecycle.UNPROCESSED
 
 
 def test_already_categorized_in_window_not_overwritten():
     near = make_item(item_name="近前", bill_time=ANCHOR_T - 100)
     near.category = ExpenseCategory.CATERING
+    near.lifecycle = Lifecycle.CLASSIFIED
     WetMarket().run([near, _anchor()], make_context())
     assert near.category == ExpenseCategory.CATERING
 
@@ -71,5 +72,5 @@ def test_no_anchor_no_change():
     a = make_item(bill_time=100)
     b = make_item(bill_time=200)
     WetMarket().run([a, b], make_context())
-    assert a.category == ExpenseCategory.UNKNOWN
-    assert b.category == ExpenseCategory.UNKNOWN
+    assert a.lifecycle == Lifecycle.UNPROCESSED
+    assert b.lifecycle == Lifecycle.UNPROCESSED


### PR DESCRIPTION
## Summary

把"用 ExpenseCategory.UNKNOWN/SKIP 表达处理状态"的隐式约定换成显式 lifecycle 状态机，让 BillItem 上的业务分类（category）与处理状态（lifecycle）职责分离。

**枚举清理**：
- `ExpenseCategory` 删除 UNKNOWN / SKIP / REFUND / INCOME 四个状态值，只保留 14 个真实业务分类
- `ClassifyAlg` 删除 UNKNOWN，未分类用 `classify_alg=None` 表达
- 新增 `Lifecycle`（UNPROCESSED / SKIPPED / CROSS_MONTH_REFUND / CLASSIFIED）+ `SkipReason`（FILTER / BLACKLIST / NON_EXPENSE / ZERO_AMOUNT / REFUND_NO_ORIG）

**职责拆分**：
- 新增 `non_expense_skip` step，把 `exact_match` 兼职的"bill_type != EXPENSE → SKIP"职责拆出来；位置：`cross_month_unified` 之后、`exact_match` 之前
- 各 step "是否已处理"判断从 `category != UNKNOWN` 改为 `lifecycle != UNPROCESSED`，语义清晰
- `main.py` 输出分流从"bill_type + category + classify_alg 三层混合"改为"lifecycle 一级 + classify_alg 二级"

**展示层**：
- BillItem 新增 `category_display()` / `classify_alg_display()`，按 lifecycle 派生表格字符串："unknown" / "skip" / "退款" / 业务分类
- 飞书表格写入逻辑改为调用这两个 helper，对用户透明

## 阶段化实施（5 个 commit）

| Phase | commit | 测试 |
|-------|--------|------|
| 1 | 新增枚举 + BillItem 字段 | 105 → 105 |
| 2 | 11 个 step 双写 lifecycle | 105 → 105 |
| 3 | 新增 non_expense_skip step | 105 → 113 |
| 4 | main.py 输出分流改造 | 113 → 113 |
| 5 | 删除旧状态值 + 测试断言改造（约 50 处） | 113 → 113 |

## Test plan

- [x] pytest 全套 113 测试通过
- [x] 端到端 dry-run 真实账单（202510）：
  - Lifecycle 分布：UNPROCESSED 210 / SKIPPED 59 / CROSS_MONTH_REFUND 2
  - skip_reason 分布：filter 17 / non_expense 17 / zero_amount 18 / refund_no_orig 4 / blacklist 3
  - 策略 2/3/4 标记数与重构前一致：taobao_balance_extra 2 / cross_month_origin 2
  - 输出分流：主表 271 / 收入 13 / 右侧提醒 2
- [ ] 用户用 zc.ini 跑一次完整 main.py 端到端验证飞书写表

## 已知 bug（不在本 PR 范围）

`merge_refund` 无 order_id → 标 SKIPPED + REFUND_NO_ORIG（保持原行为；微信红包 / 转账等条目可能被误 SKIP）。重构完后单独修，便于按 reason 精准定位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)