### PR TITLE
refactor: 厘清 lifecycle 语义，修各 step 的 SKIP / 分类边界

### DIFF
--- a/bill_classifier/bill_item.py
+++ b/bill_classifier/bill_item.py
@@ -36,7 +36,7 @@ class BillItem:
         """飞书表格'分类'列展示值（按 bill_type / lifecycle 派生）。"""
         if self.bill_type == BillType.INCOME:
             return ExpenseCategory.INCOME.to_str()
-        if self.lifecycle == Lifecycle.CLASSIFIED and self.category is not None:
+        if self.category is not None:
             return self.category.to_str()
         if self.lifecycle == Lifecycle.CROSS_MONTH_REFUND:
             return ExpenseCategory.REFUND.to_str()

--- a/bill_classifier/category.py
+++ b/bill_classifier/category.py
@@ -104,7 +104,6 @@ class SkipReason(Enum):
     BLACKLIST = "blacklist"          # skip_keywords：item_name 黑名单
     NON_EXPENSE = "non_expense"      # bill_type ∈ {INCOME, OTHER} 不计入主表合计
     ZERO_AMOUNT = "zero_amount"      # merge_refund / taobao_balance_merge 净额为 0
-    REFUND_NO_ORIG = "refund_no_orig"  # merge_refund 无 order_id（已知 bug，保持原行为）
 
     def to_str(self) -> str:
         return self.value

--- a/bill_classifier/classifiers/__init__.py
+++ b/bill_classifier/classifiers/__init__.py
@@ -18,10 +18,12 @@ DEFAULT_STEPS = [
     "merge_refund",
     "taobao_balance_merge",
     "cross_month_unified",
+    # skip_keywords 在 non_expense_skip 之前：让黑名单只看 item_name，
+    # 不被 bill_type=OTHER 的条目提前 SKIP 掉（典型：余额宝-自动转入）。
+    "skip_keywords",
     "non_expense_skip",
     "exact_match",
     "regex_match",
-    "skip_keywords",
     "wet_market",
     "neighbor_inference",
     "gpt",

--- a/bill_classifier/classifiers/exact_match.py
+++ b/bill_classifier/classifiers/exact_match.py
@@ -9,7 +9,7 @@
     2. 否则 payee 命中 payee_category_dict → 取对应 category
     3. 都不命中 → 留给后续 step
 - 命中后 classify_alg 标 ClassifyAlg.MATCH（这是 wet_market 锚点的判定条件）
-- 非支出（INCOME / OTHER）直接标 SKIP
+- 非支出（INCOME / OTHER）由 non_expense_skip 处理，本 step 不动它们
 
 依赖飞书 IO 拉取的 CategoryInfo；拉取失败时只跳过本 step，
 其他规则不受影响（ctx.category_info_loader 失败时返回 (False, None)）。
@@ -18,14 +18,13 @@
 - item_name="地铁单程票", payee="任意" → TRANSPORTATION
 - item_name="未知商品", payee="星巴克" → CATERING
 - item_name="未知", payee="未知" → 留给 regex_match / GPT
-- bill_type=INCOME 的工资记录 → SKIP
 """
 
 import logging
 from typing import List
 
 from bill_item import BillItem
-from category import BillType, ClassifyAlg, Lifecycle, SkipReason
+from category import BillType, ClassifyAlg, Lifecycle
 from classifiers.base import Context, Step
 
 logger = logging.getLogger(__name__)
@@ -51,10 +50,8 @@ class ExactMatch(Step):
             # cross_month_unified 标的 CROSS_MONTH_REFUND）跳过
             if item.lifecycle != Lifecycle.UNPROCESSED:
                 continue
-            # 防御：理论上 non_expense_skip 已把非支出标 SKIPPED，不会到这里
+            # 非 EXPENSE 不在本 step 职责范围内：不分类也不打 SKIP，原样跳过
             if item.bill_type != BillType.EXPENSE:
-                item.lifecycle = Lifecycle.SKIPPED
-                item.skip_reason = SkipReason.NON_EXPENSE
                 continue
 
             if item.item_name in info.item_category_dict:

--- a/bill_classifier/classifiers/gpt.py
+++ b/bill_classifier/classifiers/gpt.py
@@ -43,10 +43,6 @@ class GPTStep(Step):
 
     def run(self, items: List[BillItem], ctx: Context) -> List[BillItem]:
         classifier = ctx.gpt_classifier_factory()
-        if classifier is None:
-            logger.error("gpt 跳过：未提供 classifier")
-            return items
-
         call_limit = ctx.bill_config.gpt_config.call_limit
         mark_count = 0
 

--- a/bill_classifier/classifiers/merge_refund.py
+++ b/bill_classifier/classifiers/merge_refund.py
@@ -11,8 +11,7 @@
         - 净支出 ≥ 0.01 → lifecycle=UNPROCESSED + classify_alg=MERGED（中间态，
           后续分类 step 命中时会被覆盖）
         - 只有 refund_items（找不到原支出）→ 退款条目原样保留
-- 无 order_id 的记录直接标 SKIP
-  （已知问题：会丢掉微信红包 / 转账等，TODO.md 已记录）
+- 无 order_id 的记录原样 passthrough（不能按 order_id 合并，但保留交给后续 step）
 
 合并产生的条目还会写：
     is_merged = True
@@ -24,7 +23,7 @@
 - order O1：预付款 10 + 尾款 30 → 一条 40，classify_alg=MERGED
 - order O2：商品 20 - 商品退款 20 → 一条 0，SKIPPED + FULL_REFUND
 - order O3：商品 20 - 退款 5 → 一条 15，classify_alg=MERGED
-- 无 order_id 的微信红包 → SKIPPED + REFUND_NO_ORIG
+- 无 order_id 的微信红包/转账 → 原样保留，由后续 non_expense_skip / 分类 step 处理
 """
 
 import copy
@@ -54,11 +53,8 @@ class MergeRefund(Step):
 
         for item in items:
             if not item.order_id:
-                # 无 order_id 当前直接判 SKIP；TODO.md 已记账后续要修
-                item.lifecycle = Lifecycle.SKIPPED
-                item.skip_reason = SkipReason.REFUND_NO_ORIG
+                # 无 order_id 不参与按 order_id 合并，原样保留交给后续 step
                 merged_items.append(item)
-                logger.debug("退款记录丢失原始账单: {}".format(item))
                 continue
             order_items.setdefault(item.order_id, []).append(item)
 

--- a/bill_classifier/classifiers/neighbor_inference.py
+++ b/bill_classifier/classifiers/neighbor_inference.py
@@ -99,9 +99,11 @@ class NeighborInference(Step):
             )
             for ci in chain:
                 c = items[ci]
+                # 仅作"跟随锚点"的标记：写 category / FOLLOW / group_id，
+                # lifecycle 保持原状（UNPROCESSED）。下游消费时不要依赖
+                # lifecycle == CLASSIFIED 来判断这类条目。
                 c.category = anchor_item.category
                 c.classify_alg = ClassifyAlg.FOLLOW
-                c.lifecycle = Lifecycle.CLASSIFIED
                 c.group_id = group_id
                 marked_count += 1
             anchor_item.group_id = group_id

--- a/bill_classifier/classifiers/non_expense_skip.py
+++ b/bill_classifier/classifiers/non_expense_skip.py
@@ -5,10 +5,14 @@
 - 新设计：独立 step `non_expense_skip` 负责把非支出（INCOME / OTHER）标 SKIPPED，
          分类 step 只关心 UNPROCESSED 的 EXPENSE
 
-实施位置：cross_month_unified 之后、exact_match 之前。
-理由：cross_month_unified 已经把"跨月退款"挑出来标 CROSS_MONTH_REFUND（这些是
-OTHER 类的合法条目，需要在右侧提醒），non_expense_skip 跑到它们时
-lifecycle != UNPROCESSED 会自动跳过，不会误覆盖。
+实施位置：cross_month_unified / skip_keywords 之后、exact_match 之前。
+理由：
+- cross_month_unified 已经把"跨月退款"挑出来标 CROSS_MONTH_REFUND（这些是
+  OTHER 类的合法条目，需要在右侧提醒），non_expense_skip 跑到它们时
+  lifecycle != UNPROCESSED 会自动跳过，不会误覆盖。
+- skip_keywords 也排在前面，让 item_name 黑名单优先于 bill_type 判断生效
+  （否则像"余额宝-自动转入"这种 bill_type=OTHER 的条目会被本 step 抢先以
+  NON_EXPENSE 的理由 SKIP 掉，黑名单永远没机会标 BLACKLIST）。
 
 举例：
 - bill_type=INCOME（工资、转账收）→ SKIPPED + NON_EXPENSE

--- a/bill_classifier/classifiers/skip_keywords.py
+++ b/bill_classifier/classifiers/skip_keywords.py
@@ -3,13 +3,19 @@
 逻辑：
 - 一些转账类的 item_name 在飞书分类表里没维护，但又确定不算开销
   （资金搬运、内部转账等），用一个 in-memory 列表直接判 SKIP
-- 仅对仍是 UNKNOWN 的 item 生效
+- 仅对仍是 UNPROCESSED 的 item 生效；不看 bill_type
 - 默认黑名单见 SKIP_ITEM_NAMES；构造时可传 names 覆盖
 
+实施位置：cross_month_unified 之后、non_expense_skip 之前。
+理由：黑名单是基于 item_name 的硬规则，应优先于 bill_type 判断生效。
+比如"余额宝-自动转入" bill_type 通常是"不计收支"(OTHER)，如果排在
+non_expense_skip 之后，会被前者以 NON_EXPENSE 的理由先 SKIP 掉，
+本 step 的 BLACKLIST 标签就永远打不出来。
+
 举例（默认黑名单：余额宝-自动转入、转账备注:微信转账）：
-- item_name="余额宝-自动转入" → SKIP（资金从余额转到余额宝，不算开销）
-- item_name="转账备注:微信转账" → SKIP
-- item_name="正常商品名" → 保持 UNKNOWN，留给后续 step
+- item_name="余额宝-自动转入" → SKIP + BLACKLIST
+- item_name="转账备注:微信转账" → SKIP + BLACKLIST
+- item_name="正常商品名" → 保持 UNPROCESSED，留给后续 step
 """
 
 import logging

--- a/bill_classifier/main.py
+++ b/bill_classifier/main.py
@@ -150,18 +150,20 @@ def split_for_output(bill_item_list):
         if it.bill_type == BillType.INCOME:
             income_data.append(it)
             continue
-        if it.lifecycle == Lifecycle.CLASSIFIED:
-            bucket = classified_buckets.get(it.classify_alg)
-            if bucket is not None:
-                bucket.append(it)
-            else:
-                # 防御：未知 classify_alg，归到 unprocessed
-                unprocessed_data.append(it)
-        elif it.lifecycle == Lifecycle.CROSS_MONTH_REFUND:
-            cross_month_data.append(it)
-        elif it.lifecycle == Lifecycle.SKIPPED:
+        # SKIPPED / CROSS_MONTH_REFUND 是终态展示分组，先于按 classify_alg 分桶。
+        # （注意：skip_keywords 把 classify_alg 标 MATCH 但 lifecycle=SKIPPED，
+        #   必须先按 lifecycle 拦截，否则会被错误归到 MATCH bucket。）
+        if it.lifecycle == Lifecycle.SKIPPED:
             skipped_data.append(it)
-        else:  # UNPROCESSED
+            continue
+        if it.lifecycle == Lifecycle.CROSS_MONTH_REFUND:
+            cross_month_data.append(it)
+            continue
+        bucket = classified_buckets.get(it.classify_alg)
+        if bucket is not None:
+            bucket.append(it)
+        else:
+            # 包括 classify_alg=None（真未分类）以及 MERGED 等中间态
             unprocessed_data.append(it)
 
     main_data = []

--- a/tests/test_exact_match.py
+++ b/tests/test_exact_match.py
@@ -26,10 +26,14 @@ def test_payee_hit_when_item_name_miss():
     assert item.category == ExpenseCategory.CATERING
 
 
-def test_non_expense_marked_skip():
+def test_non_expense_left_untouched():
+    """非 EXPENSE 不在本 step 职责内：不分类也不打 SKIP，由 non_expense_skip 负责。"""
     item = make_item(item_name="工资", bill_type=BillType.INCOME)
     ExactMatch().run([item], make_context(info=_info()))
-    assert item.lifecycle == Lifecycle.SKIPPED
+    assert item.lifecycle == Lifecycle.UNPROCESSED
+    assert item.category is None
+    assert item.classify_alg is None
+    assert item.skip_reason is None
 
 
 def test_already_categorized_skipped():

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -72,7 +72,3 @@ def test_empty_response_does_not_set_category():
     assert item.lifecycle == Lifecycle.UNPROCESSED
 
 
-def test_no_classifier_skips_step():
-    item = make_item(item_name="x", payee="y")
-    GPTStep().run([item], make_context(gpt_classifier=None, bill_config=_bill_config()))
-    assert item.lifecycle == Lifecycle.UNPROCESSED

--- a/tests/test_merge_refund.py
+++ b/tests/test_merge_refund.py
@@ -4,11 +4,13 @@ from classifiers.merge_refund import MergeRefund
 from helpers import make_context, make_item
 
 
-def test_no_order_id_marked_skip():
+def test_no_order_id_passthrough():
     item = make_item(amount=10, order_id="")
     out = MergeRefund().run([item], make_context())
     assert len(out) == 1
-    assert out[0].lifecycle == Lifecycle.SKIPPED
+    assert out[0] is item
+    assert out[0].lifecycle == Lifecycle.UNPROCESSED
+    assert out[0].skip_reason is None
 
 
 def test_single_item_with_order_id_passthrough():

--- a/tests/test_neighbor_inference.py
+++ b/tests/test_neighbor_inference.py
@@ -29,7 +29,8 @@ def test_single_meituan_then_match_anchor_forms_group():
     anchor = _match_anchor(T0 + 180)
     NeighborInference().run([target, anchor], make_context())
 
-    assert target.lifecycle == Lifecycle.CLASSIFIED
+    # neighbor_inference 只是标记，不推进 lifecycle
+    assert target.lifecycle == Lifecycle.UNPROCESSED
     assert target.category == ExpenseCategory.CATERING
     assert target.classify_alg == ClassifyAlg.FOLLOW
     expected = f"nbr:{anchor.order_id}"


### PR DESCRIPTION
## Summary

- **lifecycle 仅作 step 入口判断**（"是否已处理"），不再承担"是否分类完"的双重含义；展示和分桶改看 `category` / `classify_alg`。
- **修复 skip_keywords 对 alipay `余额宝-自动转入` 不生效的 bug**：调整 `DEFAULT_STEPS` 顺序，让黑名单优先于 `non_expense_skip` 的 bill_type 判断生效。
- **修复 merge_refund 误吞无 order_id 条目的已知 bug**（旧实现把所有无单号的微信红包/转账判为 SKIP）。

## 各 step 调整

| step | 改动 | 原因 |
|---|---|---|
| `merge_refund` | 无 order_id 不再 SKIP，原样 passthrough；删 `SkipReason.REFUND_NO_ORIG` | 旧逻辑把无单号的真实支出（微信红包/转账等）误吞 |
| `exact_match` | 删除非 EXPENSE 的防御性 SKIP | 职责归 `non_expense_skip`，避免双写 |
| `neighbor_inference` | 链命中只写 `category / FOLLOW / group_id`，不再 set lifecycle | "只是标记"，不是终态裁决 |
| `gpt` | 删除 `classifier=None` 的兜底分支 | 工厂保证返回非空，不需要 None 兜底 |
| `skip_keywords` | DEFAULT_STEPS 中提到 `non_expense_skip` 之前 | 让 item_name 黑名单优先于 bill_type 判断生效 |

## 下游展示同步改造

- `bill_item.category_display()`：删除 `lifecycle == CLASSIFIED` 检查，category 非空就显示（兼容 neighbor_inference 不动 lifecycle 的新行为）
- `main.split_for_output()`：先按 `SKIPPED` / `CROSS_MONTH_REFUND` 拦截，再按 `classify_alg` 分桶；`FOLLOW` 类条目能正确进 FOLLOW 桶（之前会进 unprocessed）

## Bad case 验证

`/Users/caowx/Library/CloudStorage/Dropbox/账单/202604/zrz_alipay.csv` 中 `余额宝-自动转入`：

- 改前：`lifecycle=SKIPPED, skip_reason=NON_EXPENSE, classify_alg=None`（被 non_expense_skip 抢先标）
- 改后：`lifecycle=SKIPPED, skip_reason=BLACKLIST, classify_alg=MATCH` ✓

## Test plan
- [x] `pytest tests/` — 112 passed（4 个测试同步更新断言）
- [x] 真实 alipay 文件验证 `余额宝-自动转入` 现在命中 BLACKLIST
- [ ] 手工跑一次完整 pipeline，看飞书表分桶/展示是否符合预期

🤖 Generated with [Claude Code](https://claude.com/claude-code)